### PR TITLE
Added Vehicle Cache

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -61,7 +61,7 @@ AddEventHandler('qb-vehicletuning:server:UpdateDrivingDistance', function(amount
     if (not IsVehicleOwned(plate)) then
         return
     end
-    
+
     local result = exports.ghmattimysql:executeSync('SELECT plate FROM player_vehicles WHERE plate=@plate', {['@plate'] = plate})
     if result[1] ~= nil then
         exports.ghmattimysql:execute('UPDATE player_vehicles SET drivingdistance=@drivingdistance WHERE plate=@plate', {['@drivingdistance'] = amount, ['@plate'] = plate})
@@ -71,7 +71,8 @@ end)
 QBCore.Functions.CreateCallback('qb-vehicletuning:server:IsVehicleOwned', function(source, cb, plate)
 
     if (VehicleCache[plate] ~= nil) then
-        return VehicleCache[plate]
+        cb(VehicleCache[plate])
+        return
     end
 
     local retval = false


### PR DESCRIPTION
Feel free to correct me if I'm wrong, but I don't see the point in checking the database every second for if the vehicle is owned, when it could be stored in a Lua table and then checked in there instead. I have the cache clear every 5 minutes, since the table can get quite large on bigger servers, with people jumping in/out of local cars etc.