### PR TITLE
fix: load locales before config

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,9 +6,9 @@ version '2.0.1'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',
-    'config.lua',
     'locales/en.lua',
-    'locales/*.lua'
+    'locales/*.lua',
+    'config.lua',
 }
 
 client_scripts {


### PR DESCRIPTION
**Describe Pull request**
The config uses translations so they must be loaded before the config.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
