### PR TITLE
[OPTIMIZATION] Fix driving distance update time

### DIFF
--- a/client/drivingdistance.lua
+++ b/client/drivingdistance.lua
@@ -112,6 +112,7 @@ CreateThread(function()
                             local amount = round(DrivingDistance[plate] / 1000, -2)
 
                             TriggerEvent('hud:client:UpdateDrivingMeters', true, amount)
+                            Wait(60000) -- Wait However long youd like this is Every Minute and then will Update Driving Distance every Minute (60 seconds)
                             TriggerServerEvent('qb-vehicletuning:server:UpdateDrivingDistance', DrivingDistance[plate], plate)
                         end
                     else

--- a/client/drivingdistance.lua
+++ b/client/drivingdistance.lua
@@ -112,7 +112,7 @@ CreateThread(function()
                             local amount = round(DrivingDistance[plate] / 1000, -2)
 
                             TriggerEvent('hud:client:UpdateDrivingMeters', true, amount)
-                            Wait(60000) -- Wait However long youd like this is Every Minute and then will Update Driving Distance every Minute (60 seconds)
+                            Wait(60000) -- Wait However long you'd like this is Every Minute and then will Update Driving Distance every Minute (60 seconds)
                             TriggerServerEvent('qb-vehicletuning:server:UpdateDrivingDistance', DrivingDistance[plate], plate)
                         end
                     else

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-MechanicJob'
-version '2.1.0'
+version '2.1.1'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',


### PR DESCRIPTION
**Describe Pull request**
Makes the Driving Distance update every 60 seconds/minute

If your PR is to fix an issue mention that issue here
#60 This is the fix and is optimized to 0.0 -> 0.01 on update

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [**yes**/no] (Be honest)
- Does your code fit the style guidelines? [**yes**/no]
- Does your PR fit the contribution guidelines? [**yes**/no]

