### PR TITLE
replace Config.Damages by locale

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -140,9 +140,9 @@ Config.MinimalMetersForDamage = {
 }
 
 Config.Damages = {
-    ["radiator"] = "Radiator",
-    ["axle"] = "Drive Shaft",
-    ["brakes"] = "Brakes",
-    ["clutch"] = "Clutch",
-    ["fuel"] = "Fuel Tank",
+    ["radiator"] = Lang:t('labels.radiator'),
+    ["axle"] = Lang:t('labels.axle'),
+    ["brakes"] = Lang:t('labels.brakes'),
+    ["clutch"] = Lang:t('labels.clutch'),
+    ["fuel"] = Lang:t('labels.fuel'),
 }


### PR DESCRIPTION
It looks a little bit crazy to use locale for Config.ValuesLabels, but use english names for Config.Damages. Both can use same translations - or is there a problem?

BTW: 
- Config.Vehicles
- Config.Businesses
- Config.RepairCost should get a locale variable for translations, too.