### PR TITLE
Move strings to locale

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -512,7 +512,7 @@ local function PartsMenu()
                 end
                 vehicleMenu[#vehicleMenu+1] = {
                     header = v,
-                    txt = "Status: " .. percentage .. ".0% / 100.0%",
+                    txt = Lang:t('parts_menu.status') .. percentage .. ".0% / 100.0%",
                     params = {
                         event = "qb-mechanicjob:client:PartMenu",
                         args = {
@@ -665,7 +665,7 @@ local function VehicleList()
         }
     end
     vehicleMenu[#vehicleMenu+1] = {
-        header = "⬅ Close Menu",
+        header = Lang:t('nodamage_menu.c_menu'),
         txt = "",
         params = {
             event = "qb-menu:client:closeMenu"

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-MechanicJob'
-version '2.1.0'
+version '2.1.1'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',


### PR DESCRIPTION
Lines 515 vs. 531 ("Status" vs. "Status") are equal to each other so here we can use this locale variable again. Lines 601 vs. 668 ("Close menu" vs. "Close menu") are equal to each other so here we can use this locale variable again.

--

Notice:
- Line 650 with "Vehicle list" needs a locale variable and has to be replaced.
- Line 657 with "Vehicle:" needs a locale variable and has to be replaced.