### PR TITLE
Feature/add blip customization

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -986,16 +986,18 @@ CreateThread(function()
         Wait(wait)
     end
 
-    local Blip = AddBlipForCoord(Config.Locations["exit"].x, Config.Locations["exit"].y, Config.Locations["exit"].z)
-    SetBlipSprite (Blip, 446)
-    SetBlipDisplay(Blip, 4)
-    SetBlipScale  (Blip, 0.7)
-    SetBlipAsShortRange(Blip, true)
-    SetBlipColour(Blip, 0)
-    SetBlipAlpha(Blip, 0.7)
-    BeginTextCommandSetBlipName("STRING")
-    AddTextComponentSubstringPlayerName(Lang:t('labels.job_blip'))
-    EndTextCommandSetBlipName(Blip)
+    if Config.Blip['showBlip'] then
+        local Blip = AddBlipForCoord(Config.Locations["exit"].x, Config.Locations["exit"].y, Config.Locations["exit"].z)
+        SetBlipSprite (Blip, Config.Blip['sprite'])
+        SetBlipDisplay(Blip, Config.Blip['display'])
+        SetBlipScale  (Blip, Config.Blip['scale'])
+        SetBlipAsShortRange(Blip, Config.Blip['asShortRange'])
+        SetBlipColour(Blip, Config.Blip['colour'])
+        SetBlipAlpha(Blip, Config.Blip['alpha'])
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentSubstringPlayerName(Lang:t('labels.job_blip'))
+        EndTextCommandSetBlipName(Blip)
+    end
 
     RegisterGarageZone()
     RegisterDutyTarget()

--- a/config.lua
+++ b/config.lua
@@ -98,6 +98,16 @@ Config.Plates = {
     },
 }
 
+Config.Blip = {
+    ['showBlip'] = true, -- change to false if you want to disable blip
+    ['sprite'] = 446,
+    ['display'] = 4,
+    ['scale'] = 0.7,
+    ['asShortRange'] = true,
+    ['colour'] = 0,
+    ['alpha'] = 0.7 
+}
+
 Config.Locations = {
     ["exit"] = vector3(-339.04, -135.53, 39),
     ["duty"] = vector3(-323.39, -129.6, 39.01),

--- a/config.lua
+++ b/config.lua
@@ -105,7 +105,7 @@ Config.Blip = {
     ['scale'] = 0.7,
     ['asShortRange'] = true,
     ['colour'] = 0,
-    ['alpha'] = 0.7 
+    ['alpha'] = 0.7
 }
 
 Config.Locations = {


### PR DESCRIPTION
**Describe Pull request**
This PR adds the ability to customize the main (exit) location map blip. 
Gives the ability to admins/devs to add color, change blip icons, scale, etc. 

It also has the feature of enabling/disabling the actual blip. 


If your PR is to fix an issue mention that issue here
N/A

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
