### PR TITLE
Update en.lua

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,7 +1,7 @@
 local Translations = {
     labels = {
         engine = 'Motor',
-        bodsy = 'Body',
+        body = 'Body',
         radiator = 'Radiator',
         axle = 'Drive Shaft',
         brakes = 'Brakes',


### PR DESCRIPTION
After yesterday up on a spelling error, I have install a qbcore server on my pc to test things and upon start server, after qb-mechanicjob was started, all scripts went yellow for warning. Error message was Warning: Missing phrase for key: "labels.body". After I made the change, it was working fine again.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
