### PR TITLE
Save Vehicle Paints

### DIFF
--- a/client/cosmetic.lua
+++ b/client/cosmetic.lua
@@ -656,6 +656,10 @@ RegisterNetEvent('qb-mechanicjob:client:vehicleSetColors', function(netId, secti
         local pearlescentColor, _ = GetVehicleExtraColours(vehicle)
         SetVehicleExtraColours(vehicle, pearlescentColor, tonumber(colorIndex))
     end
+
+        
+    local props = QBCore.Functions.GetVehicleProperties(vehicle)
+    TriggerServerEvent('qb-mechanicjob:server:SaveVehicleProps', props)
 end)
 
 RegisterNetEvent('qb-mechanicjob:client:startParticles', function(netId, color)


### PR DESCRIPTION
this update saves the paints to the vehicle. prior the paint would reset upon taking it out of the garage.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
