### PR TITLE
🐛 onResourceStart fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -2,7 +2,7 @@ PlayerData = {}
 
 -- Handlers
 
-AddEventHandler('OnResourceStart', function(resourceName)
+AddEventHandler('onResourceStart', function(resourceName)
     if (GetCurrentResourceName() ~= resourceName) then return end
     PlayerData = QBCore.Functions.GetPlayerData()
 end)


### PR DESCRIPTION
**Describe Pull request**
As simple as lowercasing the first letter of the _**o**nResourceStart_ It was declared as _**O**nResourceStart_ which doesn't exist.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**
