### PR TITLE
Added option to remove the exterior and interior mods

### DIFF
--- a/client/cosmetic.lua
+++ b/client/cosmetic.lua
@@ -196,6 +196,21 @@ function InteriorModList(id, vehicle, label)
             args = {}
         }
     }
+
+    mods[#mods + 1] = {
+        header = Lang:t('menu.defaultmod'),
+            params = {
+                isAction = true,
+                event = function(data)
+                    SetVehicleModKit(vehicle, 0)
+                    SetVehicleMod(vehicle, data.modType, -1, false)
+                    InteriorModList(id, vehicle, label)
+                end,
+                args = {
+                }
+            }
+    }
+    
     for i = 0, GetNumVehicleMods(vehicle, id) - 1 do
         local modHeader
         if id == 14 then
@@ -253,6 +268,7 @@ function ExteriorModList(id, vehicle, label)
     local mods = { { header = label, isMenuHeader = true, icon = 'fas fa-car-side' } }
     mods[#mods + 1] = {
         header = Lang:t('menu.back'),
+        icon = 'fas fa-backward',
         params = {
             isAction = true,
             event = function()
@@ -264,7 +280,6 @@ function ExteriorModList(id, vehicle, label)
     
     mods[#mods + 1] = {
         header = Lang:t('menu.defaultmod'),
-        icon = 'fas fa-backward',
         params = {
             isAction = true,
             event = function()

--- a/client/cosmetic.lua
+++ b/client/cosmetic.lua
@@ -253,7 +253,6 @@ function ExteriorModList(id, vehicle, label)
     local mods = { { header = label, isMenuHeader = true, icon = 'fas fa-car-side' } }
     mods[#mods + 1] = {
         header = Lang:t('menu.back'),
-        icon = 'fas fa-backward',
         params = {
             isAction = true,
             event = function()

--- a/client/cosmetic.lua
+++ b/client/cosmetic.lua
@@ -262,6 +262,21 @@ function ExteriorModList(id, vehicle, label)
             args = {}
         }
     }
+    
+    mods[#mods + 1] = {
+        header = Lang:t('menu.defaultmod'),
+        icon = 'fas fa-backward',
+        params = {
+            isAction = true,
+            event = function()
+                SetVehicleModKit(vehicle, 0)
+                SetVehicleMod(vehicle, id, -1, false)
+                ExteriorModList(id, vehicle, label)
+            end,
+            args = {}
+        }
+    }
+    
     for i = 1, GetNumVehicleMods(vehicle, id) - 1 do
         mods[#mods + 1] = {
             header = GetLabelText(GetModTextLabel(vehicle, id, i)),

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -23,6 +23,7 @@ local Translations = {
         none = 'None',
         back = 'Back',
         close = 'Close',
+        defaultmod = 'Default',
         submit = 'Submit',
         status = 'Status',
         vehicle_stats = 'Vehicle Stats',

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -23,6 +23,7 @@ local Translations = {
         none = 'Ninguno',
         back = 'Volver',
         close = 'Cerrar',
+        defaultmod = 'De serie',
         submit = 'Confirmar',
         status = 'Estado',
         vehicle_stats = 'Datos del vehículo',


### PR DESCRIPTION
**Describe Pull request**
I added an option in the exterior and interior menus to remove the modifications that the car has. This option is named as 'Default' and sets the default cosmetic to the car.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [ yes ]
- Does your code fit the style guidelines? [ yes ]
- Does your PR fit the contribution guidelines? [ yes ]
