### PR TITLE
Remove redundant `if` statement from `updateVehicleComponents`

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -217,11 +217,7 @@ end)
 
 RegisterNetEvent('qb-mechanicjob:server:updateVehicleComponents', function(plate, componentData)
     if plate and componentData then
-        if vehicleComponents[plate] then
-            vehicleComponents[plate] = componentData
-        else
-            vehicleComponents[plate] = componentData
-        end
+        vehicleComponents[plate] = componentData
     end
     local isOwned = IsVehicleOwned(plate)
     if isOwned then MySQL.update('UPDATE player_vehicles SET status = ? WHERE plate = ?', { json.encode(vehicleComponents[plate]), plate }) end


### PR DESCRIPTION
This is a small refactoring to drop an unnecessary `if` statement where both branches are doing the same. I'm not sure what was the initial intention and perhaps we should instead fix one of the branches to perform some other action but I can't guess what it was supposed to do be so I just suggest a refactoring that results in no behavior change 

### Question for reviewers 

**Questions (please complete the following information):**
- [x] I've loaded the code on our qbcore server
- [x] Code fits the style guide 
- [x] PR fits the contribution guidelines 

